### PR TITLE
Add module EEPROM write option

### DIFF
--- a/ethtool.8.in
+++ b/ethtool.8.in
@@ -1212,6 +1212,16 @@ and
 .I length
 parameters are treated relatively to EEPROM page boundaries.
 .TP
+.B \-\-write\-module\-eeprom
+Writes bytes to the plugin module EEPROM.
+.TP
+.BI offset \ N
+.TP
+.BI length \ N
+.TP
+.BI value \ N
+If value is not specified, data is read from standard input.
+.TP
 .B \-\-show\-priv\-flags
 Queries the specified network device for its private flags.  The
 names and meanings of private flags (if any) are defined by each

--- a/netlink/extapi.h
+++ b/netlink/extapi.h
@@ -45,6 +45,7 @@ bool nl_gstats_chk(struct cmd_context *ctx);
 int nl_gstats(struct cmd_context *ctx);
 int nl_gmodule(struct cmd_context *ctx);
 int nl_smodule(struct cmd_context *ctx);
+int nl_smodule_eeprom(struct cmd_context *ctx);
 int nl_monitor(struct cmd_context *ctx);
 int nl_getmodule(struct cmd_context *ctx);
 
@@ -114,6 +115,7 @@ nl_get_eeprom_page(struct cmd_context *ctx __maybe_unused,
 #define nl_getmodule		NULL
 #define nl_gmodule		NULL
 #define nl_smodule		NULL
+#define nl_smodule_eeprom       NULL
 
 #endif /* ETHTOOL_ENABLE_NETLINK */
 

--- a/uapi/linux/ethtool.h
+++ b/uapi/linux/ethtool.h
@@ -1627,6 +1627,7 @@ enum ethtool_fec_config_bits {
 #define ETHTOOL_PHY_STUNABLE	0x0000004f /* Set PHY tunable configuration */
 #define ETHTOOL_GFECPARAM	0x00000050 /* Get FEC settings */
 #define ETHTOOL_SFECPARAM	0x00000051 /* Set FEC settings */
+#define ETHTOOL_SMODULEEEPROM	0x00000052 /* Set plug-in module eeprom */
 
 /* compatibility with older code */
 #define SPARC_ETH_GSET		ETHTOOL_GSET


### PR DESCRIPTION
## Summary
- allow setting module EEPROM values via new ioctl command
- implement `--write-module-eeprom` user command
- document new option in man page

## Testing
- `./configure`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_6880c6d712388333a320b93c8e42bf7d